### PR TITLE
Add gRPC server and GUI client templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# yellow_ketchapp
+# Yellow Ketchapp
+
+This repository provides templates for a gRPC server written in Go and a simple GUI client written in Python.
+
+- `server/` contains the Go gRPC server template.
+- `gui/` contains the Python GUI client template.
+
+Refer to the README files in each directory for details on building and running the components.

--- a/gui/README.md
+++ b/gui/README.md
@@ -1,0 +1,25 @@
+# GUI gRPC Client Template
+
+This directory contains a simple GUI application written in Python that communicates with the gRPC server.
+
+## Prerequisites
+
+- Python 3.11 or later
+- `grpcio` and `grpcio-tools` packages
+
+## Generating Code
+
+Generate the Python gRPC code from the shared `.proto` file:
+
+```bash
+python -m grpc_tools.protoc -I proto --python_out=. --grpc_python_out=. proto/helloworld.proto
+```
+
+## Running the Application
+
+After generating the code, install the required packages and run the client:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```

--- a/gui/app.py
+++ b/gui/app.py
@@ -1,0 +1,40 @@
+import grpc
+import tkinter as tk
+from tkinter import ttk
+
+import proto.helloworld_pb2 as helloworld_pb2
+import proto.helloworld_pb2_grpc as helloworld_pb2_grpc
+
+
+def send_request(channel, name):
+    stub = helloworld_pb2_grpc.GreeterStub(channel)
+    response = stub.SayHello(helloworld_pb2.HelloRequest(name=name))
+    return response.message
+
+
+def main():
+    root = tk.Tk()
+    root.title("gRPC Client")
+
+    frame = ttk.Frame(root, padding="10")
+    frame.grid(row=0, column=0, sticky=(tk.W, tk.E, tk.N, tk.S))
+
+    name_var = tk.StringVar()
+    result_var = tk.StringVar()
+
+    ttk.Label(frame, text="Name:").grid(row=0, column=0, sticky=tk.W)
+    name_entry = ttk.Entry(frame, textvariable=name_var)
+    name_entry.grid(row=0, column=1, sticky=(tk.W, tk.E))
+
+    ttk.Button(frame, text="Send", command=lambda: result_var.set(send_request(channel, name_var.get()))).grid(row=1, column=0, columnspan=2)
+    ttk.Label(frame, textvariable=result_var).grid(row=2, column=0, columnspan=2)
+
+    for child in frame.winfo_children():
+        child.grid_configure(padx=5, pady=5)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    with grpc.insecure_channel("localhost:50051") as channel:
+        main()

--- a/gui/proto/helloworld.proto
+++ b/gui/proto/helloworld.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package helloworld;
+option go_package = "server/proto";
+
+service Greeter {
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}

--- a/gui/requirements.txt
+++ b/gui/requirements.txt
@@ -1,0 +1,2 @@
+grpcio
+grpcio-tools

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,27 @@
+# Go gRPC Server Template
+
+This directory contains a minimal gRPC server written in Go.
+
+## Prerequisites
+
+- Go 1.21 or later
+- Protocol Buffers compiler (`protoc`)
+- `protoc-gen-go` and `protoc-gen-go-grpc` plugins installed
+
+## Generating Code
+
+Run the following command from this directory to generate Go code from the `.proto` file:
+
+```bash
+protoc --go_out=. --go-grpc_out=. proto/helloworld.proto
+```
+
+## Running the Server
+
+After generating the code, build and run the server:
+
+```bash
+go run .
+```
+
+The server listens on `:50051` by default and implements a simple `Greeter` service.

--- a/server/main.go
+++ b/server/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net"
+
+	pb "server/proto"
+
+	"google.golang.org/grpc"
+)
+
+type greeterServer struct {
+	pb.UnimplementedGreeterServer
+}
+
+func (s *greeterServer) SayHello(ctx context.Context, req *pb.HelloRequest) (*pb.HelloReply, error) {
+	return &pb.HelloReply{Message: "Hello " + req.Name}, nil
+}
+
+func main() {
+	lis, err := net.Listen("tcp", ":50051")
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	grpcServer := grpc.NewServer()
+	pb.RegisterGreeterServer(grpcServer, &greeterServer{})
+	log.Println("gRPC server listening on :50051")
+	if err := grpcServer.Serve(lis); err != nil {
+		log.Fatalf("failed to serve: %v", err)
+	}
+}

--- a/server/proto/helloworld.proto
+++ b/server/proto/helloworld.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package helloworld;
+option go_package = "server/proto";
+
+service Greeter {
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}


### PR DESCRIPTION
## Summary
- create Go gRPC server template in `server/`
- add Python GUI client template in `gui/`
- update root README with overview

## Testing
- `python3 -m py_compile gui/app.py`
