### PR TITLE
Add Go module for server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@
 # Fortran module files
 *.mod
 *.smod
+!go.mod
+!*/go.mod
 
 # Compiled Static libraries
 *.lai

--- a/server/README.md
+++ b/server/README.md
@@ -7,6 +7,11 @@ This directory contains a minimal gRPC server written in Go.
 - Go 1.21 or later
 - Protocol Buffers compiler (`protoc`)
 - `protoc-gen-go` and `protoc-gen-go-grpc` plugins installed
+- Initialize a Go module once in this directory:
+
+  ```bash
+  go mod init server
+  ```
 
 ## Generating Code
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,0 +1,3 @@
+module server
+
+go 1.23.8


### PR DESCRIPTION
## Summary
- unignore go.mod files so server module can be checked in
- add go.mod under `server/`
- document `go mod init server` step in server README

## Testing
- `go mod init server` *(fails: module already initialized)*
