### PR TITLE
Fix order of client setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ This repository provides templates for a gRPC server written in Go and a simple 
 - `gui/` contains the Python GUI client template.
 
 Refer to the README files in each directory for details on building and running the components.
+For the Python client specifically, make sure to install its requirements before
+generating the gRPC stubs:
+
+```bash
+pip install -r gui/requirements.txt
+```

--- a/gui/README.md
+++ b/gui/README.md
@@ -8,9 +8,19 @@ This directory contains a simple GUI application written in Python using the PyS
 - `grpcio` and `grpcio-tools` packages
 - `PySide6` for the GUI
 
+## Setup
+
+Install the required Python packages before generating any code so that the
+`grpc_tools` module is available:
+
+```bash
+pip install -r requirements.txt
+```
+
 ## Generating Code
 
-Generate the Python gRPC code from the shared `.proto` file:
+After installing the dependencies, generate the Python gRPC code from the shared
+`.proto` file:
 
 ```bash
 python -m grpc_tools.protoc -I proto --python_out=. --grpc_python_out=. proto/helloworld.proto
@@ -18,9 +28,8 @@ python -m grpc_tools.protoc -I proto --python_out=. --grpc_python_out=. proto/he
 
 ## Running the Application
 
-After generating the code, install the required packages and run the client:
+With the stubs generated and dependencies installed, start the GUI client:
 
 ```bash
-pip install -r requirements.txt
 python app.py
 ```


### PR DESCRIPTION
## Summary
- clarify that the GUI client's requirements must be installed before running `grpc_tools.protoc`
- add a short note in the project README about installing Python dependencies

## Testing
- `go vet ./...` *(fails: no required module provides package google.golang.org/grpc)*