### PR TITLE
Fix versioning and module instructions

### DIFF
--- a/gui/README.md
+++ b/gui/README.md
@@ -10,8 +10,17 @@ This directory contains a simple GUI application written in Python using the PyS
 
 ## Setup
 
-Install the required Python packages before generating any code so that the
-`grpc_tools` module is available:
+Create a Python virtual environment and install the dependencies before
+generating any code so that the `grpc_tools` module is available:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+Then install the pinned package versions listed in `requirements.txt`. Pinning
+`grpcio` and `grpcio-tools` avoids conflicts with packages such as TensorFlow
+that require `protobuf <5`:
 
 ```bash
 pip install -r requirements.txt

--- a/gui/requirements.txt
+++ b/gui/requirements.txt
@@ -1,3 +1,3 @@
-grpcio
-grpcio-tools
+grpcio==1.64.1
+grpcio-tools==1.64.1
 PySide6

--- a/server/README.md
+++ b/server/README.md
@@ -7,11 +7,8 @@ This directory contains a minimal gRPC server written in Go.
 - Go 1.21 or later
 - Protocol Buffers compiler (`protoc`)
 - `protoc-gen-go` and `protoc-gen-go-grpc` plugins installed
-- Initialize a Go module once in this directory:
-
-  ```bash
-  go mod init server
-  ```
+- This repository already includes a `go.mod` file, so you can skip running
+  `go mod init`.
 
 ## Generating Code
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,3 +1,3 @@
 module server
 
-go 1.23.8
+go 1.21


### PR DESCRIPTION
## Summary
- pin `grpcio` and `grpcio-tools` versions
- document using a virtual environment and why pins are required
- correct Go version in `go.mod`
- note existing module file in Go README

## Testing
- `go build ./...` *(fails: google.golang.org/grpc: connect: no route to host)*
- `python -m py_compile gui/app.py`