### PR TITLE
Update proto generation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ pip install -r gui/requirements.txt
 
 ## Generating gRPC Code
 
-Both components use the shared `proto/` directory. Run the commands below from
-each subdirectory to generate the language-specific stubs:
+Both components share the top-level `proto/` directory. You can generate the
+language-specific stubs from the repository root with the following commands:
 
 ```bash
-# From server/
-protoc -I ../proto --go_out=proto --go-grpc_out=proto ../proto/helloworld.proto
+# Go stubs for the server
+protoc -I ./proto --go_out=./server --go-grpc_out=./server ./proto/helloworld.proto
 
-# From gui/
-python -m grpc_tools.protoc -I ../proto --python_out=proto --grpc_python_out=proto ../proto/helloworld.proto
+# Python stubs for the GUI client
+python -m grpc_tools.protoc -I ./proto --python_out=./gui --grpc_python_out=./gui ./proto/helloworld.proto
 ```

--- a/gui/README.md
+++ b/gui/README.md
@@ -29,10 +29,10 @@ pip install -r requirements.txt
 ## Generating Code
 
 After installing the dependencies, generate the Python gRPC code from the shared
-`.proto` file:
+`.proto` file by running the command below from the repository root:
 
 ```bash
-python -m grpc_tools.protoc -I ../proto --python_out=proto --grpc_python_out=proto ../proto/helloworld.proto
+python -m grpc_tools.protoc -I ./proto --python_out=./gui --grpc_python_out=./gui ./proto/helloworld.proto
 ```
 
 ## Running the Application

--- a/server/README.md
+++ b/server/README.md
@@ -21,11 +21,11 @@ go get google.golang.org/grpc
 
 ## Generating Code
 
-Run the following command from this directory to generate Go code from the shared
-`.proto` file:
+To generate the Go code for the server, run the following command from the
+repository root:
 
 ```bash
-protoc -I ../proto --go_out=proto --go-grpc_out=proto ../proto/helloworld.proto
+protoc -I ./proto --go_out=./server --go-grpc_out=./server ./proto/helloworld.proto
 ```
 
 ## Running the Server


### PR DESCRIPTION
## Summary
- update README instructions to generate gRPC code from repository root

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*