### PR TITLE
Add proto package init

### DIFF
--- a/gui/proto/__init__.py
+++ b/gui/proto/__init__.py
@@ -1,0 +1,3 @@
+import os, sys
+sys.path.append(os.path.dirname(__file__))
+


### PR DESCRIPTION
## Summary
- fix Python gRPC import issues by adding `gui/proto/__init__.py`

## Testing
- `python -m py_compile gui/proto/__init__.py`
