### PR TITLE
Implement image listing and download in Qt Quick client

### DIFF
--- a/client_qtquick/Main.cpp
+++ b/client_qtquick/Main.cpp
@@ -1,6 +1,31 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include <QFile>
+#include <QDir>
+#include <QFileInfo>
+#include <QObject>
 #include <QtProtobufQtCoreTypes>
+
+class FileWriter : public QObject
+{
+    Q_OBJECT
+public:
+    using QObject::QObject;
+
+    Q_INVOKABLE bool save(const QString &path, const QByteArray &data)
+    {
+        QDir dir(QFileInfo(path).absolutePath());
+        if (!dir.exists())
+            dir.mkpath(".");
+        QFile file(path);
+        if (!file.open(QIODevice::WriteOnly))
+            return false;
+        file.write(data);
+        file.close();
+        return true;
+    }
+};
 
 int main(int argc, char *argv[])
 {
@@ -9,6 +34,8 @@ int main(int argc, char *argv[])
     QGuiApplication app(argc, argv);
 
     QQmlApplicationEngine engine;
+    FileWriter writer;
+    engine.rootContext()->setContextProperty("fileWriter", &writer);
     engine.loadFromModule("ClientQtQuick", "Main");
     if (engine.rootObjects().isEmpty())
         return -1;


### PR DESCRIPTION
## Summary
- expand Qt Quick client with an `ImageServiceClient`
- implement image list loading and image download in QML
- expose a `FileWriter` helper from C++ for saving downloads

## Testing
- `go vet ./server` *(fails: cannot find main module)*
- `pytest -q` *(fails: command not found)*