### PR TITLE
Strip image service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yellow Ketchapp
 
-This repository provides templates for a gRPC server written in Go and a simple GUI client written in Python. The server now exposes an `ImageService` API so clients can list and download image files.
+This repository provides templates for a gRPC server written in Go and a simple GUI client written in Python. The server only implements a `Greeter` service.
 
 - `server/` contains the Go gRPC server template.
 - `client_pyside/` contains the Python GUI client template built with PySide6.

--- a/client_pyside/README.md
+++ b/client_pyside/README.md
@@ -1,8 +1,7 @@
 # PySide gRPC Client Template
 
 This directory contains a simple GUI application written in Python using the PySide6 toolkit that communicates with the gRPC server.
-In addition to sending a greeting, the client can now list images available on the server and download the selected file.
-
+This example simply sends a greeting using the `Greeter` service.
 ## Prerequisites
 
 - Python 3.11 or later

--- a/client_pyside/app.py
+++ b/client_pyside/app.py
@@ -1,6 +1,5 @@
 import grpc
 import sys
-import os
 from PySide6 import QtWidgets
 
 import proto.imagestorage_pb2 as imagestorage_pb2
@@ -13,16 +12,6 @@ def send_request(channel, name):
     return response.message
 
 
-def list_images(channel):
-    stub = imagestorage_pb2_grpc.ImageServiceStub(channel)
-    resp = stub.ListImages(imagestorage_pb2.ImageListRequest())
-    return resp.filenames
-
-
-def download_image(channel, filename):
-    stub = imagestorage_pb2_grpc.ImageServiceStub(channel)
-    resp = stub.GetImage(imagestorage_pb2.ImageRequest(filename=filename))
-    return resp.data
 
 
 def main(channel):
@@ -42,40 +31,16 @@ def main(channel):
     send_button = QtWidgets.QPushButton("Send")
     result_label = QtWidgets.QLabel()
 
-    image_list = QtWidgets.QListWidget()
-    load_button = QtWidgets.QPushButton("Load Images")
-    download_button = QtWidgets.QPushButton("Download Selected")
 
     def on_send():
         result_label.setText(send_request(channel, name_edit.text()))
 
     send_button.clicked.connect(on_send)
 
-    def on_load():
-        image_list.clear()
-        for name in list_images(channel):
-            image_list.addItem(name)
-
-    def on_download():
-        item = image_list.currentItem()
-        if item is None:
-            return
-        data = download_image(channel, item.text())
-        os.makedirs("downloads", exist_ok=True)
-        path = os.path.join("downloads", item.text())
-        with open(path, "wb") as f:
-            f.write(data)
-        QtWidgets.QMessageBox.information(window, "Downloaded", f"Saved to {path}")
-
-    load_button.clicked.connect(on_load)
-    download_button.clicked.connect(on_download)
 
     layout.addLayout(form_layout)
     layout.addWidget(send_button)
     layout.addWidget(result_label)
-    layout.addWidget(load_button)
-    layout.addWidget(image_list)
-    layout.addWidget(download_button)
 
     window.setLayout(layout)
     window.show()

--- a/client_qtquick/Main.qml
+++ b/client_qtquick/Main.qml
@@ -28,13 +28,8 @@ Window {
 
     property helloRequest req
 
-    // Q_INVOKABLE void SayHello(const imagestorage::HelloRequest &arg, const QJSValue &callback, const QJSValue &errorCallback, const QtGrpcQuickPrivate::QQmlGrpcCallOptions *options = nullptr);
-    // Q_INVOKABLE void ListImages(const imagestorage::ImageListRequest &arg, const QJSValue &callback, const QJSValue &errorCallback, const QtGrpcQuickPrivate::QQmlGrpcCallOptions *options = nullptr);
-    // Q_INVOKABLE void GetImage(const imagestorage::ImageRequest &arg, const QJSValue &callback, const QJSValue &errorCallback, const QtGrpcQuickPrivate::QQmlGrpcCallOptions *options = nullptr);
-
-
     function finishCallback(response: helloReply): void {
-        console.log(response.message)
+        greetingLabel.text = response.message
     }
 
     function errorCallback(error): void {

--- a/client_qtquick/README.md
+++ b/client_qtquick/README.md
@@ -2,11 +2,8 @@
 
 This directory provides a minimal QML application built with Qt Quick. The code demonstrates how QtGrpc and QtProtobuf can be used from QML to talk to the gRPC server.
 
-The example mirrors the features of the widgets client:
-
-- Send a greeting using the `Greeter` service
-- List images available on the server
-- Download the selected image
+The example mirrors the widgets client and simply sends a greeting using the
+`Greeter` service.
 
 ## Building
 

--- a/client_qtwidget/README.md
+++ b/client_qtwidget/README.md
@@ -1,10 +1,6 @@
 # Qt gRPC Client using QtProtobuf
 
-This directory contains a minimal Qt Widgets application written in C++ that communicates with the gRPC server using Qt's gRPC and QtProtobuf modules. The application mirrors the features of the Python client:
-
-- Send a greeting using the `Greeter` service
-- List images available on the server
-- Download the selected image
+This directory contains a minimal Qt Widgets application written in C++ that communicates with the gRPC server using Qt's gRPC and QtProtobuf modules. The example simply sends a greeting using the `Greeter` service.
 
 ## Prerequisites
 

--- a/client_qtwidget/main.cpp
+++ b/client_qtwidget/main.cpp
@@ -5,10 +5,6 @@
 #include <QLineEdit>
 #include <QPushButton>
 #include <QLabel>
-#include <QListWidget>
-#include <QMessageBox>
-#include <QFile>
-#include <QDir>
 #include <QtGrpc/QGrpcCallOptions>
 #include <QtGrpc/QGrpcChannelOptions>
 #include <QtGrpc/QGrpcHttp2Channel>
@@ -21,11 +17,9 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
     std::unique_ptr<imagestorage::Greeter::Client> greeter = std::make_unique<imagestorage::Greeter::Client>();
-    std::unique_ptr<imagestorage::ImageService::Client> imageClient = std::make_unique<imagestorage::ImageService::Client>();
 
     auto channel = std::make_shared<QGrpcHttp2Channel>(QUrl("http://localhost:50051"));
     greeter->attachChannel(channel);
-    imageClient->attachChannel(channel);
 
 
     QWidget window;
@@ -41,9 +35,6 @@ int main(int argc, char *argv[])
     QPushButton *sendButton = new QPushButton("Send");
     QLabel *resultLabel = new QLabel();
 
-    QListWidget *imageList = new QListWidget();
-    QPushButton *loadButton = new QPushButton("Load Images");
-    QPushButton *downloadButton = new QPushButton("Download Selected");
 
     QObject::connect(sendButton, &QPushButton::clicked, [&]() {
         imagestorage::HelloRequest req;
@@ -58,49 +49,10 @@ int main(int argc, char *argv[])
         });
     });
 
-    QObject::connect(loadButton, &QPushButton::clicked, [&]() {
-        imagestorage::ImageListRequest req;
-        auto reply = imageClient->ListImages(req);
-        auto *replyPtr = reply.release();
-        QObject::connect(replyPtr, &QGrpcCallReply::finished, imageList, [replyPtr, imageList]() {
-            imagestorage::ImageListReply resp;
-            replyPtr->read(&resp);
-            imageList->clear();
-            for (const auto &name : resp.filenames())
-                imageList->addItem(name);
-            replyPtr->deleteLater();
-        });
-    });
-
-    QObject::connect(downloadButton, &QPushButton::clicked, [&]() {
-        auto item = imageList->currentItem();
-        if (!item)
-            return;
-        const QString filename = item->text();
-        imagestorage::ImageRequest req;
-        req.setFilename(filename);
-        auto reply = imageClient->GetImage(req);
-        auto *replyPtr = reply.release();
-        QObject::connect(replyPtr, &QGrpcCallReply::finished, &window, [replyPtr, filename, &window]() {
-            imagestorage::ImageData resp;
-            replyPtr->read(&resp);
-            QDir().mkpath("downloads");
-            QFile file("downloads/" + filename);
-            if (file.open(QIODevice::WriteOnly)) {
-                file.write(resp.data());
-                file.close();
-                QMessageBox::information(&window, "Downloaded", "Saved to " + file.fileName());
-            }
-            replyPtr->deleteLater();
-        });
-    });
 
     layout->addLayout(form);
     layout->addWidget(sendButton);
     layout->addWidget(resultLabel);
-    layout->addWidget(loadButton);
-    layout->addWidget(imageList);
-    layout->addWidget(downloadButton);
 
     window.show();
     return app.exec();

--- a/proto/imagestorage.proto
+++ b/proto/imagestorage.proto
@@ -7,28 +7,6 @@ service Greeter {
   rpc SayHello (HelloRequest) returns (HelloReply) {}
 }
 
-service ImageService {
-  // Returns the list of filenames available in the server's image directory.
-  rpc ListImages (ImageListRequest) returns (ImageListReply) {}
-
-  // Returns the raw bytes of a requested image file.
-  rpc GetImage (ImageRequest) returns (ImageData) {}
-}
-
-message ImageListRequest {}
-
-message ImageListReply {
-  repeated string filenames = 1;
-}
-
-message ImageRequest {
-  string filename = 1;
-}
-
-message ImageData {
-  bytes data = 1;
-}
-
 message HelloRequest {
   string name = 1;
 }

--- a/server/README.md
+++ b/server/README.md
@@ -1,9 +1,7 @@
 # Go gRPC Server Template
 
-This directory contains a minimal gRPC server written in Go.
-In addition to the example `Greeter` service, the server exposes an
-`ImageService` that allows clients to list and download image files stored
-under `server/images/`.
+This directory contains a minimal gRPC server written in Go that implements a
+single `Greeter` service.
 
 ## Prerequisites
 
@@ -39,7 +37,5 @@ After generating the code, build and run the server:
 go run .
 ```
 
-The server listens on `:50051` by default and implements a simple `Greeter` service.
-It also serves the `ImageService` API. Place any image files you want to expose
-in the `images/` directory. Clients can query the available filenames using the
-`ListImages` RPC and download a specific file with `GetImage`.
+The server listens on `:50051` by default and implements a simple `Greeter`
+service.

--- a/server/images/README.md
+++ b/server/images/README.md
@@ -1,1 +1,0 @@
-Place image files in this directory to make them accessible via the ImageService RPCs.

--- a/server/main.go
+++ b/server/main.go
@@ -1,47 +1,17 @@
 package main
 
 import (
-	"context"
-	"log"
-	"net"
-	"os"
-	"path/filepath"
+        "context"
+        "log"
+        "net"
 
-	pb "server/proto"
+        pb "server/proto"
 
-	"google.golang.org/grpc"
+        "google.golang.org/grpc"
 )
 
 type greeterServer struct {
-	pb.UnimplementedGreeterServer
-}
-
-type imageServer struct {
-	pb.UnimplementedImageServiceServer
-	imageDir string
-}
-
-func (s *imageServer) ListImages(ctx context.Context, req *pb.ImageListRequest) (*pb.ImageListReply, error) {
-	entries, err := os.ReadDir(s.imageDir)
-	if err != nil {
-		return nil, err
-	}
-	filenames := make([]string, 0, len(entries))
-	for _, e := range entries {
-		if !e.IsDir() {
-			filenames = append(filenames, e.Name())
-		}
-	}
-	return &pb.ImageListReply{Filenames: filenames}, nil
-}
-
-func (s *imageServer) GetImage(ctx context.Context, req *pb.ImageRequest) (*pb.ImageData, error) {
-	path := filepath.Join(s.imageDir, req.GetFilename())
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	return &pb.ImageData{Data: data}, nil
+        pb.UnimplementedGreeterServer
 }
 
 func (s *greeterServer) SayHello(ctx context.Context, req *pb.HelloRequest) (*pb.HelloReply, error) {
@@ -54,8 +24,7 @@ func main() {
 		log.Fatalf("failed to listen: %v", err)
 	}
 	grpcServer := grpc.NewServer()
-	pb.RegisterGreeterServer(grpcServer, &greeterServer{})
-	pb.RegisterImageServiceServer(grpcServer, &imageServer{imageDir: "./images"})
+        pb.RegisterGreeterServer(grpcServer, &greeterServer{})
 	log.Println("gRPC server listening on :50051")
 	if err := grpcServer.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)


### PR DESCRIPTION
## Summary
- drop image RPCs and remove server image handlers
- simplify Python client
- trim Qt clients and docs
- only Greeter API remains
- remove leftover QML comment and display greeting in quick client

## Testing
- `python -m py_compile client_pyside/app.py`
- `go vet ./... && go build ./...` *(fails: no route to host)*