### PR TITLE
Add Qt server implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Yellow Ketchapp
 
-This repository provides templates for gRPC servers written in Go and C++ as well as a simple client written in various GUI frameworks. The servers only implement a `Greeter` service.
+This repository provides templates for gRPC servers written in Go, C++, and Qt as well as a simple client written in various GUI frameworks. The servers only implement a `Greeter` service.
 
 - `server/go/` contains the Go gRPC server template.
 - `server/cpp/` contains a C++ gRPC server example.
+- `server/qt/` contains a Qt based gRPC server using QtProtobuf.
 - `client/pyside/` contains the Python GUI client template built with PySide6.
 - `client/qtwidget/` contains a Qt gRPC client implemented in C++ using QtProtobuf.
 - `client/qtquick/` contains a Qt Quick client implemented in QML using QtProtobuf.
@@ -32,6 +33,9 @@ python -m grpc_tools.protoc -I ./proto --python_out=./client/pyside --grpc_pytho
 # Qt C++ stubs for the Qt client
 protoc -I ./proto --qt_out=./client/qtwidget --qt-grpc_out=./client/qtwidget ./proto/helloworld.proto
 protoc -I ./proto --qt_out=./client/qtquick --qt-grpc_out=./client/qtquick ./proto/helloworld.proto
+
+# Qt C++ stubs for the Qt server
+protoc -I ./proto --qt_out=./server/qt --qt-grpc_out=./server/qt ./proto/helloworld.proto
 
 # C++ stubs for the C++ server
 protoc -I ./proto --cpp_out=./server/cpp --grpc_out=./server/cpp ./proto/helloworld.proto

--- a/server/qt/CMakeLists.txt
+++ b/server/qt/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.16)
+project(grpc_server_qt LANGUAGES CXX)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Grpc Protobuf)
+
+qt_standard_project_setup()
+
+add_executable(grpc_server_qt
+    main.cpp
+)
+
+add_library(grpc_server_qt_proto STATIC)
+qt_add_protobuf(grpc_server_qt_proto
+    PROTO_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../proto/helloworld.proto
+)
+
+qt_add_grpc(grpc_server_qt_proto SERVER
+    PROTO_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../proto/helloworld.proto
+)
+
+target_link_libraries(grpc_server_qt PRIVATE
+    Qt6::Core
+    Qt6::Grpc
+    Qt6::Protobuf
+    grpc_server_qt_proto
+)

--- a/server/qt/README.md
+++ b/server/qt/README.md
@@ -1,0 +1,30 @@
+# Qt gRPC Server using QtProtobuf
+
+This directory contains a minimal gRPC server implemented with Qt. The
+implementation uses Qt's QtGrpc and QtProtobuf modules and exposes the
+same `Greeter` service defined in `proto/helloworld.proto`.
+
+## Prerequisites
+
+- Qt 6.5 or later built with the QtGrpc and QtProtobuf modules
+- `protoc` with the Qt plugins (`protoc-gen-qt` and `protoc-gen-qtgrpc`)
+- CMake 3.16 or newer
+
+## Generating Code
+
+Generate the Qt sources from the repository root:
+
+```bash
+protoc -I ./proto --qt_out=./server/qt --qt-grpc_out=./server/qt ./proto/helloworld.proto
+```
+
+## Building
+
+```bash
+mkdir -p build && cd build
+cmake ..
+cmake --build .
+```
+
+Running the resulting `grpc_server_qt` executable will start the server on
+`:50051`.

--- a/server/qt/main.cpp
+++ b/server/qt/main.cpp
@@ -1,0 +1,30 @@
+#include <QCoreApplication>
+#include <QtGrpc/QGrpcServer>
+#include <QtGrpc/QGrpcHttp2Server>
+
+#include "helloworld.qpb.h"
+#include "helloworld_service.grpc.qpb.h"
+
+class GreeterServiceImpl : public helloworld::GreeterService
+{
+public:
+    void SayHello(helloworld::HelloReply *response,
+                  const helloworld::HelloRequest &request,
+                  const QGrpcServerCallContext &) override
+    {
+        response->setMessage(QStringLiteral("Hello %1").arg(request.name()));
+    }
+};
+
+int main(int argc, char **argv)
+{
+    QCoreApplication app(argc, argv);
+
+    QGrpcHttp2Server server;
+    GreeterServiceImpl service;
+
+    server.start(50051);
+    server.registerService(&service);
+
+    return app.exec();
+}


### PR DESCRIPTION
## Summary
- provide a Qt gRPC server example under `server/qt`
- document how to generate Qt stubs and run the server
- mention Qt server in the top level README

## Testing
- `python -m py_compile client/pyside/app.py`
- `python -m py_compile client_pyside/app.py`
- `go fmt ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*